### PR TITLE
Modify compare logic

### DIFF
--- a/src/app/components/App.tsx
+++ b/src/app/components/App.tsx
@@ -133,7 +133,7 @@ const App = () => {
         label: string;
     }
     const generateObjects = (components: Component[]) => {
-        let annotation;
+        let annotation = '';
         components.forEach((component: Component) => {
             let xmin = component.bbox[0];
             let ymin = component.bbox[1];

--- a/src/app/components/ImageHandling.ts
+++ b/src/app/components/ImageHandling.ts
@@ -210,28 +210,36 @@ const computeIoU = (component, detection) => {
     return overlap / (union - overlap);
 };
 
-// const compareSize = (component, detection) => {
-//     const overall = 360 * 640;
-//     const ads: number = Math.abs(boxArea(component.bbox) / overall - boxArea(detection.bbox) / overall);
-//     // console.log(ads);
-//     return ads;
-// };
-export const matchBoxes = (components, detections) => {
-    detections.forEach((detection) => {
-        components.forEach((component) => {
-            const iou = computeIoU(component, detection);
-            const similarity = cosine.similarity(component.label, detection.label);
+const pytha = (component, detection) => {
+    const x = Math.abs(component.bbox[0] - detection.bbox[0]);
+    const y = Math.abs(component.bbox[1] - detection.bbox[1]);
+    const length = Math.sqrt(Math.pow(x, 2) + Math.pow(y, 2));
+    return length;
+};
 
-            // check if two boxes overlapped and Check how similar the two labels of cosine are
-            if (iou >= 0.5) {
-                detection['iou'] = iou;
-                detection['labelSimilarity'] = similarity;
-                detection['design'] = component;
+export const matchBoxes = (components, detections) => {
+    const matchs = [...detections];
+    const finding = [];
+
+    for (let index = 0; index < matchs.length; index++) {
+        const match = matchs[index];
+        components.forEach((component) => {
+            const distance = pytha(component, match);
+            const iou = computeIoU(component, match);
+            const similarity = cosine.similarity(component.label, match.label);
+            if (distance < 50) {
+                // check if two boxes overlapped and Check how similar the two labels of cosine are
+                if (iou >= 0.5) {
+                    match['iou'] = iou;
+                    match['labelSimilarity'] = similarity;
+                    match['design'] = component;
+                    finding.push(match);
+                }
             }
         });
-    });
+    }
 
-    return detections;
+    return finding;
 };
 
 const drawCorrection = (matched) => {


### PR DESCRIPTION
Changes the logic comparing boxes to a method.
The existing method compares all `the sizes of the boxes`, but the new method compares `the distance between the boxes`.
We can significantly reduce the amount of code, and the comparison results are also very good.

![img](https://user-images.githubusercontent.com/4177529/156910489-277f6e0d-0e72-498c-b0d9-84e1e060f302.jpg)

